### PR TITLE
CMake support

### DIFF
--- a/clients/c++/CMakeLists.txt
+++ b/clients/c++/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(client)
+
+#set(UMBRIDGE_USE_SSL "yes")
+find_package(Umbridge REQUIRED HINTS "../../cmake")
+add_executable(http-client http-client.cpp)
+target_link_libraries(http-client PRIVATE Umbridge::Umbridge)

--- a/clients/c++/build.sh
+++ b/clients/c++/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-g++ -std=c++17 http-client.cpp -pthread -I../../lib/ -lssl -lcrypto -o http-client
+g++ -std=c++17 -DCPPHTTPLIB_OPENSSL_SUPPORT http-client.cpp -pthread -I../../lib/ -lssl -lcrypto -o http-client

--- a/clients/c++/http-client.cpp
+++ b/clients/c++/http-client.cpp
@@ -1,5 +1,5 @@
 // Needed for HTTPS
-#define CPPHTTPLIB_OPENSSL_SUPPORT
+//#define CPPHTTPLIB_OPENSSL_SUPPORT
 
 #include "umbridge.h"
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16)
+project(umbridge)
+
+install(FILES ../lib/httplib.h ../lib/umbridge.h ../lib/json.hpp
+  DESTINATION include/umbridge)
+
+install(FILES UmbridgeConfig.cmake.in
+  RENAME UmbridgeConfig.cmake
+  DESTINATION lib/cmake/Umbridge)

--- a/cmake/UmbridgeConfig.cmake
+++ b/cmake/UmbridgeConfig.cmake
@@ -1,0 +1,15 @@
+# Provide umbridge using this folder/repository
+# If the variable UMBRIDGE_USE_SSL evaluates to true,
+# UMBRIDGE_USE_SSL directly links to ssl and crypto
+find_package(Threads REQUIRED)
+
+add_library(Umbridge::Umbridge IMPORTED INTERFACE)
+
+if(UMBRIDGE_USE_SSL)
+  target_link_libraries(Umbridge::Umbridge INTERFACE Threads::Threads ssl crypto)
+  target_include_directories(Umbridge::Umbridge INTERFACE ${CMAKE_CURRENT_LIST_DIR}/../lib)
+  target_compile_definitions(Umbridge::Umbridge INTERFACE CPPHTTPLIB_OPENSSL_SUPPORT)
+else()
+  target_link_libraries(Umbridge::Umbridge INTERFACE Threads::Threads)
+  target_include_directories(Umbridge::Umbridge INTERFACE ${CMAKE_CURRENT_LIST_DIR}/../lib)
+endif()

--- a/cmake/UmbridgeConfig.cmake.in
+++ b/cmake/UmbridgeConfig.cmake.in
@@ -1,0 +1,15 @@
+# Provide umbridge using this folder/repository
+# If the variable UMBRIDGE_USE_SSL evaluates to true,
+# UMBRIDGE_USE_SSL directly links to ssl and crypto
+find_package(Threads REQUIRED)
+
+add_library(Umbridge::Umbridge IMPORTED INTERFACE)
+
+if(UMBRIDGE_USE_SSL)
+  target_link_libraries(Umbridge::Umbridge INTERFACE Threads::Threads ssl crypto)
+  target_include_directories(Umbridge::Umbridge INTERFACE ${CMAKE_CURRENT_LIST_DIR}/../../../include/umbridge)
+  target_compile_definitions(Umbridge::Umbridge INTERFACE CPPHTTPLIB_OPENSSL_SUPPORT)
+else()
+  target_link_libraries(Umbridge::Umbridge INTERFACE Threads::Threads)
+  target_include_directories(Umbridge::Umbridge INTERFACE ${CMAKE_CURRENT_LIST_DIR}/../../../include/umbridge)
+endif()


### PR DESCRIPTION
Adds 

* the folder `cmake` to the root. This folder contains two configuration files
  * `UmbridgeConfig.cmake` allows to use the repository directly
  * `UmbridgeConfig.cmake.in` will be installed when using cmake (and the corresponding CMakeLists.txt)

This way, cmake users can install the library using
```
cmake -S ./cmake -B <buildFolder>
cmake --install <buildFolder> --prefix <destFolder>
```

As this lib provides `json.hpp` and `httplib.h`, I suggest to reorganize the code a little bit to
```
cpp/include/umbridge/[umbridge | json | httplib].h
cpp/README.md
```

such the client would include `umbridge/umbridge.h`. This way you can ship your own json and httplib without getting conflicts with system provided `json.h` and `httplib.h`

What do you think?