### PR TITLE
Add CI workflow to test LB on SLURM backend

### DIFF
--- a/.github/workflows/SLURM-LB-test.yml
+++ b/.github/workflows/SLURM-LB-test.yml
@@ -1,0 +1,35 @@
+name: SLURM-LB
+
+on:
+  push:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: giovtorres/slurm-docker
+      options: --cap-add sys_admin --privileged
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check SLURM daemons are running
+        run: |
+         nohup /usr/local/bin/docker-entrypoint.sh > /tmp/entrypoint.log 2>&1 &
+          for i in $(seq 1 60); do
+            scontrol ping 2>/dev/null | grep -q UP && break
+            sleep 5
+          done
+          
+      - name: Clone UM-Bridge and run loadbalancer test
+        run: |
+         dnf -y install gcc-g++ libstdc++-static
+         python3 -m venv venv && . venv/bin/activate && pip3 install umbridge
+         git clone https://github.com/UM-Bridge/umbridge.git && cd umbridge/hpc && make 
+         sed -i -e 's|--partition=devel|--partition=normal|' slurm_scripts/job.sh
+         ./load-balancer --scheduler=slurm &
+         sleep 20 && 
+         python3 test/minimal/minimal-client.py

--- a/.github/workflows/SLURM-LB-test.yml
+++ b/.github/workflows/SLURM-LB-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
          dnf -y install gcc-g++ libstdc++-static
          python3 -m venv venv && . venv/bin/activate && pip3 install umbridge
-         git clone https://github.com/UM-Bridge/umbridge.git && cd umbridge/hpc && make 
+         cd umbridge/hpc && make 
          sed -i -e 's|--partition=devel|--partition=normal|' slurm_scripts/job.sh
          ./load-balancer --scheduler=slurm &
          sleep 20 && 

--- a/.github/workflows/SLURM-LB-test.yml
+++ b/.github/workflows/SLURM-LB-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
          dnf -y install gcc-g++ libstdc++-static
          python3 -m venv venv && . venv/bin/activate && pip3 install umbridge
-         cd umbridge/hpc && make 
+         cd hpc && make 
          sed -i -e 's|--partition=devel|--partition=normal|' slurm_scripts/job.sh
          ./load-balancer --scheduler=slurm &
          sleep 20 && 


### PR DESCRIPTION
- Uses `giovtorres/slurm-docker` image on DockerHub to setup SLURM environment in the runner. Note that this image uses Rocky Linux 10.

- Will compile the minimal model and connect through the minimal client.