### PR TITLE
Numpy json fix

### DIFF
--- a/.github/workflows/pip-update.yml
+++ b/.github/workflows/pip-update.yml
@@ -14,6 +14,11 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/umbridge
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -27,7 +32,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pip-update.yml
+++ b/.github/workflows/pip-update.yml
@@ -1,26 +1,19 @@
 # This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
-
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-
 name: Upload Python Package
-
 on:
   push:
     branches:
       - 'main'
-
 permissions:
   contents: read
-
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -34,8 +27,8 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      continue-on-error: true
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        skip-existing: true

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="umbridge",
-    version="1.2.5",
+    version="1.2.6",
     author="UM-Bridge",
     author_email="",
     description="UM-Bridge (the UQ and Model Bridge) provides a unified interface for numerical models that is accessible from virtually any programming language or framework. It is primarily intended for coupling advanced models (e.g. simulations of complex physical processes) to advanced statistical or optimization methods.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="umbridge",
-    version="1.2.6",
+    version="1.2.7",
     author="UM-Bridge",
     author_email="",
     description="UM-Bridge (the UQ and Model Bridge) provides a unified interface for numerical models that is accessible from virtually any programming language or framework. It is primarily intended for coupling advanced models (e.g. simulations of complex physical processes) to advanced statistical or optimization methods.",

--- a/umbridge/um.py
+++ b/umbridge/um.py
@@ -6,6 +6,17 @@ from multiprocessing import shared_memory
 import numpy as np
 import threading
 
+
+def _to_native(value):
+    # Convert numpy scalar/array types to native Python types.
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, list):
+        return [_to_native(v) for v in value]
+    return value
+
 class Model(object):
 
     def __init__(self, name):
@@ -413,7 +424,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
                 if len(output[i]) != output_sizes[i]:
                     return error_response("InvalidOutput", f"Output vector {i} has invalid length! Model declared {output_sizes[i]} but returned {len(output[i])}.", 500)
 
-        return web.Response(text=f"{{\"output\": {output} }}")
+        return web.Response(text=f"{{\"output\": {_to_native(output)} }}")
 
     @routes.post('/EvaluateShMem')
     async def evaluate(request):
@@ -519,7 +530,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
             if len(output) != input_sizes[in_wrt]:
                 return error_response("InvalidOutput", f"Output vector has invalid length! Model declared {input_sizes[in_wrt]} but returned {len(output)}.", 500)
 
-        return web.Response(text=f"{{\"output\": {output} }}")
+        return web.Response(text=f"{{\"output\": {_to_native(output)} }}")
 
     
     @routes.post('/GradientShMem')
@@ -631,7 +642,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
             if len(output) != output_sizes[out_wrt]:
                 return error_response("InvalidOutput", f"Output vector has invalid length! Model declared {output_sizes[out_wrt]} but returned {len(output)}.", 500)
 
-        return web.Response(text=f"{{\"output\": {output} }}")
+        return web.Response(text=f"{{\"output\": {_to_native(output)} }}")
 
     @routes.post('/ApplyJacobianShMem')
     async def applyjacobian(request):
@@ -744,7 +755,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
             if len(output) != output_sizes[out_wrt]:
                 return error_response("InvalidOutput", f"Output vector has invalid length! Model declared {output_sizes[out_wrt]} but returned {len(output)}.", 500)
 
-        return web.Response(text=f"{{\"output\": {output} }}")
+        return web.Response(text=f"{{\"output\": {_to_native(output)} }}")
     
     @routes.post('/ApplyHessianShMem')
     async def applyhessian(request):
@@ -817,7 +828,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
         model = get_model_from_name(model_name)
         if model is None:
             return model_not_found_response(req_json["name"])
-        return web.Response(text=f"{{\"inputSizes\": {model.get_input_sizes(config)} }}")
+        return web.Response(text=f"{{\"inputSizes\": {_to_native(model.get_input_sizes(config))} }}")
 
     @routes.post('/OutputSizes')
     async def get_output_sizes(request):
@@ -830,7 +841,7 @@ def serve_models(models, port=4242, max_workers=1, error_checks=True):
         model = get_model_from_name(model_name)
         if model is None:
             return model_not_found_response(req_json["name"])
-        return web.Response(text=f"{{\"outputSizes\": {model.get_output_sizes(config)} }}")
+        return web.Response(text=f"{{\"outputSizes\": {_to_native(model.get_output_sizes(config))} }}")
 
     @routes.post('/ModelInfo')
     async def modelinfo(request):


### PR DESCRIPTION
Removes user/password inputs; adds permissions: id-token: write and a pypi deployment environment
Re-pins gh-action-pypi-publish from a 2021 commit (predates Trusted Publishing) to release/v1.13
Adds skip-existing: true so routine pushes to main without a version bump don't fail (previously masked by a blanket continue-on-error, which also hid real failures)